### PR TITLE
Stop collecting imports (leads to long lines)

### DIFF
--- a/IntelliJ/citrine_intellij.xml
+++ b/IntelliJ/citrine_intellij.xml
@@ -19,7 +19,6 @@
   </MarkdownNavigatorCodeStyleSettings>
   <ScalaCodeStyleSettings>
     <option name="classCountToUseImportOnDemand" value="1000000000" />
-    <option name="collectImports" value="false" />
     <option name="importMembersUsingUnderScore" value="false" />
     <option name="KEEP_COMMENTS_ON_SAME_LINE" value="true" />
   </ScalaCodeStyleSettings>

--- a/IntelliJ/citrine_intellij.xml
+++ b/IntelliJ/citrine_intellij.xml
@@ -19,6 +19,7 @@
   </MarkdownNavigatorCodeStyleSettings>
   <ScalaCodeStyleSettings>
     <option name="classCountToUseImportOnDemand" value="1000000000" />
+    <option name="collectImports" value="false" />
     <option name="importMembersUsingUnderScore" value="false" />
     <option name="KEEP_COMMENTS_ON_SAME_LINE" value="true" />
   </ScalaCodeStyleSettings>

--- a/citrine-scala-style.xml
+++ b/citrine-scala-style.xml
@@ -133,7 +133,7 @@
    <parameter name="regex"><![CDATA[^[A-Z_]$]]></parameter>
   </parameters>
  </check>
- <check level="error" class="org.scalastyle.scalariform.UnderscoreImportChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.UnderscoreImportChecker" enabled="true"></check>
  <check level="error" class="org.scalastyle.scalariform.LowercasePatternMatchChecker" enabled="true"></check>
  <check level="error" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" enabled="false">
   <parameters>


### PR DESCRIPTION
This changes the IntelliJ setting to stop collecting imports with common packages into a single line. (This often leads to scalastyle-breaking long lines.)

Thoughts @CitrineInformatics/engineering-employee ?
